### PR TITLE
Remove `-d` short flag for `--dangerous` ⛑️

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ struct Args {
     path: String,
 
     /// Only use this if you trust the authors of the document
-    #[arg(short, long)]
+    #[arg(long)]
     dangerous: bool,
 
     /// File to write output to [default: stdout]


### PR DESCRIPTION
It should be very easily visible that a "dangerous" mode is used. With the short `-d` this is not very apparent.
