### PR TITLE
[8] Allow images to load for Vim plugin

### DIFF
--- a/plugin/maxdown.vim
+++ b/plugin/maxdown.vim
@@ -53,16 +53,11 @@ function! s:show(fpath, title) abort
   endtry
 endfunction
 
-function! s:tempname(ext) abort
-  let temp = tempname()
-  return temp . a:ext
-endfunction
-
 function! s:preview() abort
   let source = expand('%:p')
-  let temp = s:tempname('.html')
-  call s:convert(temp, source, bufnr('%'))
-  call s:show(temp, expand('%:t'))
+  let dest = expand('~/.maxdown.preview.html')
+  call s:convert(dest, source, bufnr('%'))
+  call s:show(dest, expand('%:t'))
 endfunction
 
 nnoremap <silent> <Plug>MaxdownCompile :call <SID>compile()<CR>


### PR DESCRIPTION
Instead of writing a tmp file for the HTML, we put a normal file into the user's home directory. Doing so, Quick Look allows us to access any file path (e.g. for images) on the system. Assuming the source Markdown file is also somewhere in the tree below the user's home directory.
