### PR TITLE
Simplify…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,7 +299,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "markdown",
- "regex",
  "trycmd",
 ]
 
@@ -389,35 +379,6 @@ checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
 ]
-
-[[package]]
-name = "regex"
-version = "1.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rustix"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +303,7 @@ dependencies = [
 name = "maxdown"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "markdown",
  "trycmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -18,15 +18,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
 dependencies = [
  "utf8parse",
 ]
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "2.1.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -85,9 +85,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.4"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d7b8d5ec32af0fadc644bf1fd509a688c2103b185644bb1e29d164e0703136"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.4"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5179bb514e4d7c2051749d8fcefa2ed6d06a9f4e6d69faf3805f5d80b8cf8d56"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
 dependencies = [
  "anstream",
  "anstyle",
@@ -191,9 +191,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "add4f07d43996f76ef320709726a556a9d4f965d9410d8d0271132d2f8293480"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "filetime"
@@ -236,9 +236,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 
 [[package]]
 name = "heck"
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -280,9 +280,9 @@ checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
 
 [[package]]
 name = "markdown"
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "d2f9da0cbd88f9f09e7814e388301c8414c51c62aa6ce1e4b5c551d49d96e531"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -451,9 +451,9 @@ checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
 name = "snapbox"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad90eb3a2e3a8031d636d45bd4832751aefd58a291b553f7305a2bacae21aff3"
+checksum = "7b439536a42c43be148b610c7f7f968fb79a457254910a9cb20900da73cd3271"
 dependencies = [
  "anstream",
  "anstyle",
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "snapbox-macros"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f4ffd811b87da98d0e48285134b7847954bd76e843bb794a893b47ca3ee325"
+checksum = "ed1559baff8a696add3322b9be3e940d433e7bb4e38d79017205fd37ff28b28e"
 dependencies = [
  "anstream",
 ]
@@ -534,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "trycmd"
-version = "0.14.17"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6a42f89ccf3c6ee115608a68e256c172734d525a4ac36d4a17a6d4a8108149"
+checksum = "a5bff680f217f2c7cc246aa5313ef9c1802449b1b8f859d28765355fda1c421f"
 dependencies = [
  "glob",
  "humantime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.4.4", features = ["derive"] }
 markdown = "1.0.0-alpha.14"
-regex = "1.9.5"
 
 [dev-dependencies]
 trycmd = "0.14.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = { version = "1.0.75", features = ["std"] }
 clap = { version = "4.4.4", features = ["derive"] }
 markdown = "1.0.0-alpha.14"
 

--- a/examples/basic.in/template.html
+++ b/examples/basic.in/template.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <html>
   <head><title>Fancy Template</title></head>
-  <body>{{ result }}</body>
+  <body>{{ content }}</body>
 </html>

--- a/examples/basic.md
+++ b/examples/basic.md
@@ -15,7 +15,6 @@ $ maxdown input.md
   </head>
   <body class="markdown-body">
     <p>Hello <strong>Markdown</strong>!</p>
-
   </body>
 </html>
 
@@ -36,7 +35,6 @@ $ maxdown --title "Pizzazz" input.md
   </head>
   <body class="markdown-body">
     <p>Hello <strong>Markdown</strong>!</p>
-
   </body>
 </html>
 
@@ -57,7 +55,6 @@ $ maxdown --base "https://github.com/pmeinhardt/maxdown" input.md
   </head>
   <body class="markdown-body">
     <p>Hello <strong>Markdown</strong>!</p>
-
   </body>
 </html>
 
@@ -72,8 +69,7 @@ $ maxdown --template template.html input.md
 <!DOCTYPE html>
 <html>
   <head><title>Fancy Template</title></head>
-  <body><p>Hello <strong>Markdown</strong>!</p>
-</body>
+  <body><p>Hello <strong>Markdown</strong>!</p></body>
 </html>
 
 

--- a/examples/read-stdin.stdout
+++ b/examples/read-stdin.stdout
@@ -5,7 +5,6 @@
   </head>
   <body class="markdown-body">
     <p>Hello I/O!</p>
-
   </body>
 </html>
 

--- a/examples/write-file.out/output.html
+++ b/examples/write-file.out/output.html
@@ -5,6 +5,5 @@
   </head>
   <body class="markdown-body">
     <p>Just here for the input.</p>
-
   </body>
 </html>

--- a/src/default-template.html
+++ b/src/default-template.html
@@ -9,10 +9,10 @@
         padding: 2rem;
       }
 
-      {{ css }}
+      {{ default-css }}
     </style>
   </head>
   <body class="markdown-body">
-    {{ result }}
+    {{ content }}
   </body>
 </html>

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use std::process;
 
 use clap::Parser;
 use markdown;
-use regex::Regex;
 
 const TEMPLATE: &str = include_str!("default-template.html");
 const CSS: &str = include_str!("github.css");
@@ -81,17 +80,12 @@ fn convert(input: &str, dangerous: bool) -> Result<String, String> {
     markdown::to_html_with_options(input, &options)
 }
 
-fn replace(template: &str, key: &str, value: &str) -> String {
-    let pattern = [r"\{\{\s*", key, r"\s*\}\}"].join("");
-    let re = Regex::new(&pattern).unwrap();
-    re.replace_all(template, value).to_string()
-}
-
 fn render(template: &str, values: &HashMap<&str, &str>) -> String {
     let mut result = String::from(template);
 
     for (key, value) in values {
-        result = replace(&result, key, value);
+        let pattern = format!("{{{{ {key} }}}}");
+        result = result.replace(&pattern, value)
     }
 
     result

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ fn main() {
     let values = HashMap::from([
         ("base", &*base),
         ("css", &*CSS),
-        ("result", &*html),
+        ("result", html.trim()),
         ("title", &*args.title),
     ]);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,8 +106,8 @@ fn main() {
 
     let values = HashMap::from([
         ("base", &*base),
-        ("css", &*CSS),
-        ("result", html.trim()),
+        ("content", html.trim()),
+        ("default-css", CSS),
         ("title", &*args.title),
     ]);
 


### PR DESCRIPTION
- remove [`regex`](https://github.com/rust-lang/regex) crate
- rename template placeholders
- use [`anyhow`](https://github.com/dtolnay/anyhow) for error handling
- trim generated markdown