### PR TITLE
Add a `:MaxdownConvert` command

### DIFF
--- a/plugin/maxdown.vim
+++ b/plugin/maxdown.vim
@@ -25,24 +25,36 @@ function! s:compile() abort
 endfunction
 
 function! s:convert() abort
-  execute '%!' . s:cmd . ' -'
+  let cmd = s:cmd
+
+  let args = [
+        \ '--template', shellescape(s:path . '/src/minimal-template.html'),
+        \ '--title', shellescape(expand('%:t')),
+        \ '-',
+        \ ]
+
+  for arg in args
+    let cmd .= ' ' . arg
+  endfor
+
+  execute '%!' . cmd
 endfunction
 
 function! s:invoke(dest, source, bnum) abort
-  let l:cmd = s:cmd
+  let cmd = s:cmd
 
   let args = [
         \ '--dangerous',
-        \ '--base ' . shellescape(a:source),
-        \ '--output ' . shellescape(a:dest),
+        \ '--base', shellescape(a:source),
+        \ '--output', shellescape(a:dest),
         \ '-'
         \ ]
 
   for arg in args
-    let l:cmd .= ' ' . arg
+    let cmd .= ' ' . arg
   endfor
 
-  call s:exec(l:cmd, a:bnum)
+  call s:exec(cmd, a:bnum)
 endfunction
 
 function! s:show(fpath, title) abort

--- a/plugin/maxdown.vim
+++ b/plugin/maxdown.vim
@@ -24,7 +24,11 @@ function! s:compile() abort
   call s:exec('cd ' . s:path . ' && cargo build --release --locked')
 endfunction
 
-function! s:convert(dest, source, bnum) abort
+function! s:convert() abort
+  execute '%!' . s:cmd . ' -'
+endfunction
+
+function! s:invoke(dest, source, bnum) abort
   let l:cmd = s:cmd
 
   let args = [
@@ -58,12 +62,14 @@ endfunction
 function! s:preview() abort
   let source = expand('%:p')
   let dest = expand('~/.maxdown.preview.html')
-  call s:convert(dest, source, bufnr('%'))
+  call s:invoke(dest, source, bufnr('%'))
   call s:show(dest, expand('%:t'))
 endfunction
 
 nnoremap <silent> <Plug>MaxdownCompile :call <SID>compile()<CR>
+nnoremap <silent> <Plug>MaxdownConvert :call <SID>convert()<CR>
 nnoremap <silent> <Plug>MaxdownPreview :call <SID>preview()<CR>
 
 command! MaxdownCompile call s:compile()
+command! MaxdownConvert call s:convert()
 command! MaxdownPreview call s:preview()

--- a/plugin/maxdown.vim
+++ b/plugin/maxdown.vim
@@ -34,11 +34,7 @@ function! s:convert() abort
         \ '-',
         \ ]
 
-  for arg in args
-    let cmd .= ' ' . arg
-  endfor
-
-  execute '%!' . cmd
+  execute '%!' . join([cmd] + args)
 endfunction
 
 function! s:invoke(dest, source, bnum) abort
@@ -51,11 +47,7 @@ function! s:invoke(dest, source, bnum) abort
         \ '-'
         \ ]
 
-  for arg in args
-    let cmd .= ' ' . arg
-  endfor
-
-  call s:exec(cmd, a:bnum)
+  call s:exec(join([cmd] + args), a:bnum)
 endfunction
 
 function! s:show(fpath, title) abort

--- a/plugin/maxdown.vim
+++ b/plugin/maxdown.vim
@@ -28,6 +28,7 @@ function! s:convert() abort
   let cmd = s:cmd
 
   let args = [
+        \ '--dangerous',
         \ '--template', shellescape(s:path . '/src/minimal-template.html'),
         \ '--title', shellescape(expand('%:t')),
         \ '-',

--- a/src/minimal-template.html
+++ b/src/minimal-template.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>{{ title }}</title>
+  </head>
+  <body>
+    {{ content }}
+  </body>
+</html>


### PR DESCRIPTION
This replaces the current buffer content with the result from filtering it through the `maxdown` command-line tool.

| Before | After |
|--------|--------|
| ![](https://github.com/pmeinhardt/maxdown/assets/706519/6e221e6e-ac29-445f-8128-1b87268b16b7) | ![](https://github.com/pmeinhardt/maxdown/assets/706519/acbfa6de-2a48-4005-a052-44e2c8c9105d) |

