### PR TITLE
Refactor and clean up

### DIFF
--- a/examples/error.md
+++ b/examples/error.md
@@ -5,7 +5,7 @@ Print error when input file cannot be read:
 ```console
 $ maxdown enoent.md
 ? failed
-Error: Failed to read input from enoent.md
+Error: Failed to read input from "enoent.md"
 
 Caused by:
     No such file or directory (os error 2)
@@ -17,7 +17,7 @@ Print error when template file cannot be read:
 ```console
 $ maxdown --template enoent.html input.md
 ? failed
-Error: Failed to read template from enoent.html
+Error: Failed to read template from "enoent.html"
 
 Caused by:
     No such file or directory (os error 2)
@@ -29,7 +29,7 @@ Print error when output file cannot be written:
 ```console
 $ maxdown --output enoent/output.html input.md
 ? failed
-Error: Failed to write output to enoent/output.html
+Error: Failed to write output to "enoent/output.html"
 
 Caused by:
     No such file or directory (os error 2)

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,19 +76,18 @@ fn main() -> Result<()> {
         slurp(&args.path).with_context(|| format!("Failed to read input from {:?}", args.path))?;
 
     let html = convert(&input, args.dangerous).map_err(|m| anyhow!(m))?;
-    let base = args.base.unwrap_or(String::from(""));
 
     let values = HashMap::from([
-        ("base", &*base),
+        ("base", args.base.as_deref().unwrap_or("")),
+        ("title", args.title.as_ref()),
         ("content", html.trim()),
-        ("title", &*args.title),
     ]);
 
     let template = match args.template {
         Some(path) => {
             read(&path).with_context(|| format!("Failed to read template from {:?}", path))?
         }
-        None => String::from(TEMPLATE),
+        None => TEMPLATE.to_string(),
     };
 
     let result = render(&template, &values);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use markdown::message::Message;
 use std::collections::HashMap;
-use std::fs::{self, read_to_string as read, write};
+use std::fs::{self, write};
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -39,7 +39,7 @@ struct Args {
     title: String,
 }
 
-fn slurp(path: &Path) -> Result<String, io::Error> {
+fn read(path: &Path) -> Result<String, io::Error> {
     if path == Path::new("-") {
         return io::read_to_string(io::stdin());
     }
@@ -73,7 +73,7 @@ fn main() -> Result<()> {
     let args = Args::parse();
 
     let input =
-        slurp(&args.path).with_context(|| format!("Failed to read input from {:?}", args.path))?;
+        read(&args.path).with_context(|| format!("Failed to read input from {:?}", args.path))?;
 
     let html = convert(&input, args.dangerous).map_err(|m| anyhow!(m))?;
 


### PR DESCRIPTION
This pull request refactors the codebase to improve path handling by replacing `String` with `PathBuf` for file paths and enhances error messages for better clarity. The changes also include minor adjustments to imports and function implementations to support the new `PathBuf` usage.

### Improvements to path handling:

* Replaced `String` with `PathBuf` for `path`, `output`, and `template` fields in the `Args` struct for more robust and idiomatic path handling. (`src/main.rs`, [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL18-R19) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL30-R43)
* Updated the `slurp` function to `read`, changing its parameter type from `&str` to `&Path` for compatibility with `PathBuf`. (`src/main.rs`, [src/main.rsL30-R43](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL30-R43))
* Adjusted the `main` function to use `PathBuf` and updated error messages to include `Debug` formatting (`{:?}`) for paths, ensuring clearer output. (`src/main.rs`, [src/main.rsL75-R97](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL75-R97))

### Enhancements to error messages:

* Improved error messages in `examples/error.md` to include quotes around file paths, making them more readable and consistent. [[1]](diffhunk://#diff-23ce747b292b3260f5497ed8ef9927e68bd801004062740b670e1fa97430cc27L8-R8) [[2]](diffhunk://#diff-23ce747b292b3260f5497ed8ef9927e68bd801004062740b670e1fa97430cc27L20-R20) [[3]](diffhunk://#diff-23ce747b292b3260f5497ed8ef9927e68bd801004062740b670e1fa97430cc27L32-R32)

### Miscellaneous updates:

* Removed unused `read_to_string` import and added `Path` and `PathBuf` imports to align with the updated path handling logic. (`src/main.rs`, [src/main.rsL4-R6](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL4-R6))